### PR TITLE
added class selector to initialize example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npm install accordion-js
 ###### Initialize the module
 ```javascript
 <script>
-	var accordion = new Accordion('accordion-container');	
+	var accordion = new Accordion('.accordion-container');	
 </script>
 ```
 


### PR DESCRIPTION
Initialize module example needed a '.' before accordion-container.